### PR TITLE
"For a star to be a debris disk" => "For a star to have a debris disk"

### DIFF
--- a/app/lib/tutorial.coffee
+++ b/app/lib/tutorial.coffee
@@ -30,7 +30,7 @@ module.exports =
     explain2: new Step
       number: 3
       header: "Using the Interface"
-      details: "For a star to be a debris disk, it should mostly be contained within the red circle."
+      details: "For a star to have a debris disk, it should mostly be contained within the red circle."
       attachment: "center top #question center bottom"
       next: "scrub"
 


### PR DESCRIPTION
I'm being überpedantic here so feel free to ignore, but whilst taking the tutorial I got distracted by the sentence

```
"For a star to be a debris disk..."
```

which should probably be

```
"For a star to have a debris disk..."
```

Nice project though :-)
